### PR TITLE
Fix: Change Base Labels to CamelCase for ArgoCD ApplicationSets Compatibility

### DIFF
--- a/pkg/argo_connector.go
+++ b/pkg/argo_connector.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	BASE_LABEL          string = "kubermatic-argocd-bridge"
-	TIMEOUT_START_LABEL        = BASE_LABEL + "/timeout-start"
-	MANAGED_LABEL              = BASE_LABEL + "/managed"
-	CLUSTER_ID_LABEL           = BASE_LABEL + "/cluster-id"
-	SEED_LABEL                 = BASE_LABEL + "/seed"
+	BASE_LABEL          string = "KubermaticArgocdBridge"
+	TIMEOUT_START_LABEL        = BASE_LABEL + "TimeoutStart"
+	MANAGED_LABEL              = BASE_LABEL + "Managed"
+	CLUSTER_ID_LABEL           = BASE_LABEL + "ClusterId"
+	SEED_LABEL                 = BASE_LABEL + "Seed"
 	ARGO_CLUSTER_LABEL  string = "argocd.argoproj.io/secret-type=cluster"
 )
 


### PR DESCRIPTION
**Description:**

This pull request addresses an issue with ArgoCD ApplicationSets where labels containing `'-'` cannot be reused due to invalid characters. To resolve this, I have updated the base labels to use camelCase instead.

**Example:**
```yaml
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  name: my-applicationset
  namespace: argocd
spec:
  goTemplate: true
  goTemplateOptions: ["missingkey=zero"]
  generators:
    - clusters:
        selector:
          matchLabels:
            "clusterType": "usercluster"
        values:
          clusterId: '{{.metadata.labels.kubermatic-argocd-bridge/cluster-id}}'
```
Here are the log errors from ArgoCD that prompted these changes:
```md
Message: error appending templated values for cluster: failed to replace templated string: failed to replace templated string with rendered values: failed to parse template {{.metadata.labels.kubermatic-argocd-bridge/cluster-id}}: template: :1: bad character U+002D '-'
Reason: ApplicationGenerationFromParamsError
```

**Changes:**
- Updated all base labels to camelCase.
- Ensured compatibility with ArgoCD ApplicationSets by removing invalid characters.

**Testing:**
- Confirmed that ArgoCD ApplicationSets can now reuse the labels without issues.