### PR TITLE
feat: adds kubernetes infos to cluster-secret e.g. kubernetes version

### DIFF
--- a/cmd/template/cluster-secret.yaml
+++ b/cmd/template/cluster-secret.yaml
@@ -1,6 +1,7 @@
 name: "usercluster-{{ .UserCluster.ID }}" # Changing this will result in a recreate of the secret
 labels:
   argocd.argoproj.io/secret-type: cluster
+  argocd.argoproj.io/auto-label-cluster-info: "true"
   "{{ .BaseLabel }}/managed": "true" # You should not change this atm, required to clean up clusters when they dont exist
   "{{ .BaseLabel }}/cluster-id": "{{ .UserCluster.ID }}" # You should not change this atm
   "{{ .BaseLabel }}/seed": "{{ .UserCluster.Seed.Name }}" # You should not change this atm

--- a/pkg/argo_connector.go
+++ b/pkg/argo_connector.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/base64"
 	stdErrors "errors"
+	"log"
+	"text/template"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,8 +16,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"log"
-	"text/template"
 )
 
 const (
@@ -113,6 +114,8 @@ func (connector *ArgoConnector) StoreClusterI(userCluster UserCluster, project K
 		return err
 	}
 
+	labels["argocd.argoproj.io/auto-label-cluster-info"] = "true"
+
 	annotations, err := FlattenToStringStringMap(filledTemplate["annotations"])
 
 	if err != nil {
@@ -158,6 +161,8 @@ func (connector *ArgoConnector) StoreClusterI(userCluster UserCluster, project K
 		for key, value := range annotations {
 			secret.Annotations[key] = value
 		}
+
+		secret.Labels["argocd.argoproj.io/auto-label-cluster-info"] = "true"
 
 		delete(secret.Labels, TIMEOUT_START_LABEL)
 


### PR DESCRIPTION
Related to: https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Cluster/#fetch-clusters-based-on-their-k8s-version
The label argocd.argoproj.io/auto-label-cluster-info: "true" automatically enriches the cluster-secret with kubernetes infos.