### PR TITLE
feat: Add option to load MachineDeployment infos for Secret Template

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             {{ if and .Values.clusterSecretTemplate.configmapName .Values.clusterSecretTemplate.configmapKey }}
             - "-cluster-secret-template=/etc/cluster-secret-template.yaml"
             {{ end }}
+            {{ if .Values.kkp.fetchMachineDeployments }}
+            - "-fetch-machine-deployments"
+            {{ end }}
           image: "{{ .Values.image.registry }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           name: kubermatic-argocd-bridge

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -20,6 +20,7 @@ kkp:
       # secretName: "kkp-kubeconfig"
       # secretKey: "kubeconfig"
   # kkpClusterName: "my-kkp-cluster"
+  fetchMachineDeployments: false
 argo:
   namespace: "argocd"
   auth:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,14 +3,15 @@ package main
 import (
 	_ "embed"
 	"flag"
-	bridge "github.com/svalabs/kubermatic-argocd-bridge/pkg"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	"log"
 	"os"
 	"path/filepath"
 	"time"
+
+	bridge "github.com/svalabs/kubermatic-argocd-bridge/pkg"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 )
 
 // Default cluster secret template
@@ -31,6 +32,7 @@ func main() {
 	cleanupRemovedClusters := flag.Bool("cleanup-removed-clusters", false, "Cleanup removed clusters")
 	cleanupTimedClusters := flag.Bool("cleanup-timed-clusters", false, "Cleanup clusters from removed/unavailable clusters")
 	clusterTimeoutTime := flag.Duration("cluster-timeout-time", 30*time.Second, "Time before a cluster gets deleted, when cleanup-timed-clusters is enabled ")
+	fetchMachineDeployments := flag.Bool("fetch-machine-deployments", false, "Fetch machine deployments from UserCluster and make them available to the Cluster Secret Template")
 
 	flag.Parse()
 
@@ -60,7 +62,7 @@ func main() {
 		log.Fatal("Failed to generate Argo KKP KubeConfig: ", err)
 	}
 
-	kkpArgoBridge, err := bridge.NewBridge(kkpKubeConfig, *kkpClusterName, argoKubeConfig, *argoCdNamespace, *refreshInterval, clusterSecretTemplate, *cleanupRemovedClusters, *cleanupTimedClusters, *clusterTimeoutTime)
+	kkpArgoBridge, err := bridge.NewBridge(kkpKubeConfig, *kkpClusterName, argoKubeConfig, *argoCdNamespace, *refreshInterval, clusterSecretTemplate, *cleanupRemovedClusters, *cleanupTimedClusters, *clusterTimeoutTime, *fetchMachineDeployments)
 
 	if err != nil {
 		log.Fatal("Failed to initiate bridge", err)

--- a/pkg/bridge.go
+++ b/pkg/bridge.go
@@ -8,26 +8,28 @@ import (
 	"syscall"
 	"time"
 
+	"log"
+
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"log"
 )
 
 type KKPArgoBridge struct {
-	kkpClusterName         string
-	argoCDNamespace        string
-	argoClient             *kubernetes.Clientset
-	kkpDynamicClient       *dynamic.DynamicClient
-	kkpStaticClient        *kubernetes.Clientset
-	refreshTime            time.Duration
-	clusterSecretTemplate  string
-	cleanupRemovedClusters bool
-	cleanupTimedClusters   bool
-	clusterTimeout         time.Duration
+	kkpClusterName          string
+	argoCDNamespace         string
+	argoClient              *kubernetes.Clientset
+	kkpDynamicClient        *dynamic.DynamicClient
+	kkpStaticClient         *kubernetes.Clientset
+	refreshTime             time.Duration
+	clusterSecretTemplate   string
+	cleanupRemovedClusters  bool
+	cleanupTimedClusters    bool
+	clusterTimeout          time.Duration
+	fetchMachineDeployments bool
 }
 
-func NewBridge(kkpKubeConfig *restclient.Config, kkpClusterName string, argoKubeConfig *restclient.Config, argoCdNamespace string, duration time.Duration, clusterSecretTemplate string, cleanupRemovedClusters bool, cleanupTimedClusters bool, clusterTimeout time.Duration) (*KKPArgoBridge, error) {
+func NewBridge(kkpKubeConfig *restclient.Config, kkpClusterName string, argoKubeConfig *restclient.Config, argoCdNamespace string, duration time.Duration, clusterSecretTemplate string, cleanupRemovedClusters bool, cleanupTimedClusters bool, clusterTimeout time.Duration, fetchMachineDeployments bool) (*KKPArgoBridge, error) {
 	if kkpKubeConfig == nil {
 		return nil, errors.New("kkpKubeConfig is nil")
 	}
@@ -52,23 +54,24 @@ func NewBridge(kkpKubeConfig *restclient.Config, kkpClusterName string, argoKube
 		return nil, err
 	}
 	return &KKPArgoBridge{
-		kkpClusterName:         kkpClusterName,
-		argoCDNamespace:        argoCdNamespace,
-		argoClient:             argoClient,
-		kkpDynamicClient:       kkpClient,
-		kkpStaticClient:        kkpStaticClient,
-		refreshTime:            duration,
-		clusterSecretTemplate:  clusterSecretTemplate,
-		cleanupRemovedClusters: cleanupRemovedClusters,
-		cleanupTimedClusters:   cleanupTimedClusters,
-		clusterTimeout:         clusterTimeout,
+		kkpClusterName:          kkpClusterName,
+		argoCDNamespace:         argoCdNamespace,
+		argoClient:              argoClient,
+		kkpDynamicClient:        kkpClient,
+		kkpStaticClient:         kkpStaticClient,
+		refreshTime:             duration,
+		clusterSecretTemplate:   clusterSecretTemplate,
+		cleanupRemovedClusters:  cleanupRemovedClusters,
+		cleanupTimedClusters:    cleanupTimedClusters,
+		clusterTimeout:          clusterTimeout,
+		fetchMachineDeployments: fetchMachineDeployments,
 	}, nil
 }
 
 func (bridge *KKPArgoBridge) Connect() {
 	log.Println("Creating Bridge")
 
-	kkpConnector := NewKKPConnector(bridge.kkpDynamicClient, bridge.kkpStaticClient)
+	kkpConnector := NewKKPConnector(bridge.kkpDynamicClient, bridge.kkpStaticClient, bridge.fetchMachineDeployments)
 	argoConnector := NewArgoConnector(bridge.argoClient, bridge.argoCDNamespace, bridge.kkpClusterName, bridge.clusterSecretTemplate)
 
 	err := kkpConnector.VerifyCRD()

--- a/pkg/kkp_connector.go
+++ b/pkg/kkp_connector.go
@@ -2,18 +2,20 @@ package pkg
 
 import (
 	"context"
+	"log"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"log"
 )
 
 type KKPConnector struct {
-	dynamicClient dynamic.DynamicClient
-	staticClient  kubernetes.Clientset
-	seedSchema    schema.GroupVersionResource
-	projectSchema schema.GroupVersionResource
+	dynamicClient           dynamic.DynamicClient
+	staticClient            kubernetes.Clientset
+	seedSchema              schema.GroupVersionResource
+	projectSchema           schema.GroupVersionResource
+	fetchMachineDeployments bool
 }
 type KKPProject struct {
 	Name    string
@@ -21,7 +23,7 @@ type KKPProject struct {
 	RawData map[string]interface{}
 }
 
-func NewKKPConnector(dynamicClient *dynamic.DynamicClient, staticClient *kubernetes.Clientset) *KKPConnector {
+func NewKKPConnector(dynamicClient *dynamic.DynamicClient, staticClient *kubernetes.Clientset, fetchMachineDeployments bool) *KKPConnector {
 
 	return &KKPConnector{
 		dynamicClient: *dynamicClient,
@@ -36,6 +38,7 @@ func NewKKPConnector(dynamicClient *dynamic.DynamicClient, staticClient *kuberne
 			Version:  "v1",
 			Resource: "projects",
 		},
+		fetchMachineDeployments: fetchMachineDeployments,
 	}
 }
 
@@ -59,6 +62,10 @@ func (connector *KKPConnector) GetSeeds() ([]KKPSeed, error) {
 		kubeconfigSpec := spec["kubeconfig"].(map[string]interface{})
 		kubeconfigName := kubeconfigSpec["name"].(string)
 		kubeconfigNamespace := kubeconfigSpec["namespace"].(string)
+		var managementProxySettings map[string]interface{}
+		if spec["managementProxySettings"] != nil {
+			managementProxySettings = spec["managementProxySettings"].(map[string]interface{})
+		}
 
 		kubeconfigSecret, err := connector.staticClient.CoreV1().Secrets(kubeconfigNamespace).Get(context.TODO(), kubeconfigName, metav1.GetOptions{})
 		if err != nil {
@@ -66,7 +73,7 @@ func (connector *KKPConnector) GetSeeds() ([]KKPSeed, error) {
 			continue
 		}
 
-		seed, err := NewSeed(name, kubeconfigSecret.Data["kubeconfig"])
+		seed, err := NewSeed(name, kubeconfigSecret.Data["kubeconfig"], connector.fetchMachineDeployments, managementProxySettings)
 		if err != nil {
 			log.Printf("Failed to create seed %s: %s\n", name, err)
 			continue

--- a/pkg/kkp_seed.go
+++ b/pkg/kkp_seed.go
@@ -2,32 +2,40 @@ package pkg
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"log"
 )
 
 type KKPSeed struct {
-	Name          string
-	KubeConfig    restclient.Config
-	dynamicClient dynamic.DynamicClient
-	staticClient  kubernetes.Interface
-	clusterSchema schema.GroupVersionResource
+	Name                    string
+	KubeConfig              restclient.Config
+	dynamicClient           dynamic.DynamicClient
+	staticClient            kubernetes.Interface
+	clusterSchema           schema.GroupVersionResource
+	machineDeploymentSchema schema.GroupVersionResource
+	fetchMachineDeployments bool
+	ManagementProxy         map[string]interface{}
 }
 
 type UserCluster struct {
-	Seed       *KKPSeed
-	ID         string
-	Name       string
-	kubeconfig []byte `json:"-"`
-	RawData    map[string]interface{}
+	Seed               *KKPSeed
+	ID                 string
+	Name               string
+	kubeconfig         []byte `json:"-"`
+	RawData            map[string]interface{}
+	MachineDeployments []map[string]interface{}
 }
 
-func NewSeed(name string, kubeconfig []byte) (*KKPSeed, error) {
+func NewSeed(name string, kubeconfig []byte, fetchMachineDeployments bool, managementProxySettings map[string]interface{}) (*KKPSeed, error) {
 	loadedKubeConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
 	if err != nil {
 		return nil, err
@@ -44,15 +52,22 @@ func NewSeed(name string, kubeconfig []byte) (*KKPSeed, error) {
 	}
 
 	return &KKPSeed{
-		Name:          name,
-		KubeConfig:    *loadedKubeConfig,
-		dynamicClient: *dynamicClient,
-		staticClient:  staticClient,
+		Name:                    name,
+		KubeConfig:              *loadedKubeConfig,
+		dynamicClient:           *dynamicClient,
+		staticClient:            staticClient,
+		fetchMachineDeployments: fetchMachineDeployments,
 		clusterSchema: schema.GroupVersionResource{
 			Group:    "kubermatic.k8c.io",
 			Version:  "v1",
 			Resource: "clusters",
 		},
+		machineDeploymentSchema: schema.GroupVersionResource{
+			Group:    "cluster.k8s.io",
+			Version:  "v1alpha1",
+			Resource: "machinedeployments",
+		},
+		ManagementProxy: managementProxySettings,
 	}, nil
 }
 
@@ -76,14 +91,69 @@ func (seed *KKPSeed) GetUserClusters() ([]UserCluster, error) {
 			continue
 		}
 
+		var machineDeployments []map[string]interface{}
+		if seed.fetchMachineDeployments {
+			machineDeployments, err = seed.fetchMachineDeploymentsForUserCluster(kubeConfigSecret.Data["kubeconfig"])
+			if err != nil {
+				log.Printf("Failed to fetch MachineDeployments for UserCluster %s: %s\n", name, err)
+				continue
+			}
+		}
+
 		clusters = append(clusters, UserCluster{
-			Seed:       seed,
-			ID:         id,
-			Name:       name,
-			kubeconfig: kubeConfigSecret.Data["kubeconfig"],
-			RawData:    cluster.Object,
+			Seed:               seed,
+			ID:                 id,
+			Name:               name,
+			kubeconfig:         kubeConfigSecret.Data["kubeconfig"],
+			RawData:            cluster.Object,
+			MachineDeployments: machineDeployments,
 		})
 	}
 
 	return clusters, nil
+}
+
+func (seed *KKPSeed) fetchMachineDeploymentsForUserCluster(kubeconfig []byte) ([]map[string]interface{}, error) {
+	loadedKubeConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if seed.ManagementProxy != nil {
+		proxyHost, _ := seed.ManagementProxy["proxyHost"].(string)
+		proxyProtocol, _ := seed.ManagementProxy["proxyProtocol"].(string)
+		if proxyHost != "" && proxyProtocol != "" {
+
+			proxyURL := &url.URL{
+				Scheme: proxyProtocol,
+				Host:   proxyHost,
+			}
+
+			if seed.ManagementProxy["proxyPort"] != nil {
+				proxyURL = &url.URL{
+					Scheme: proxyProtocol,
+					Host:   fmt.Sprintf("%s:%d", proxyHost, seed.ManagementProxy["proxyPort"]),
+				}
+			}
+			loadedKubeConfig.Proxy = http.ProxyURL(proxyURL)
+		}
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(loadedKubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := dynamicClient.Resource(seed.machineDeploymentSchema).Namespace("kube-system").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var machineDeployments []map[string]interface{}
+
+	for _, machineDeployment := range list.Items {
+		machineDeployments = append(machineDeployments, machineDeployment.Object)
+	}
+
+	return machineDeployments, nil
 }


### PR DESCRIPTION
With this the ability to load information about the userclusters machinedeployments was added.

To use is, set `kkp.fetchMachineDeployments` to true in your values and access the Data usin f.e.



`    annotations:
      {{ range .UserCluster.MachineDeployments }}
      {{.metadata.name}}: "{{.spec.replicas}}"
      {{ end }} 
`